### PR TITLE
Closed #4: Upgraded CryptoExchange.NET dependency.

### DIFF
--- a/Okex.Net/Okex.Net.csproj
+++ b/Okex.Net/Okex.Net.csproj
@@ -7,7 +7,7 @@
   <PropertyGroup>
     <PackageId>OKEx.Net</PackageId>
     <Authors>Burak Öner</Authors>
-    <PackageVersion>1.1.2</PackageVersion>
+    <PackageVersion>1.1.3</PackageVersion>
     <Description>Okex.Net is a .Net wrapper for the Okex API. It includes all features the API provides, REST API and Websocket, using clear and readable objects including but not limited to Reading market info, Placing and managing orders and Reading balances and funds</Description>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <PackageTags>OKEx OKEx.Net C# .Net CryptoCurrency Exchange Rest API and WebSocket API Wrapper</PackageTags>
@@ -51,9 +51,9 @@ First Release</PackageReleaseNotes>
   <PropertyGroup>
     <DocumentationFile></DocumentationFile>
     <PackageIconUrl />
-    <Version>1.1.2</Version>
-    <AssemblyVersion>1.1.2.0</AssemblyVersion>
-    <FileVersion>1.1.2.0</FileVersion>
+    <Version>1.1.3</Version>
+    <AssemblyVersion>1.1.3.0</AssemblyVersion>
+    <FileVersion>1.1.3.0</FileVersion>
     <PackageProjectUrl>https://github.com/burakoner/OKEx.Net</PackageProjectUrl>
     <RepositoryUrl>https://github.com/burakoner/OKEx.Net</RepositoryUrl>
   </PropertyGroup>
@@ -67,6 +67,6 @@ First Release</PackageReleaseNotes>
     </None>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="CryptoExchange.Net" Version="3.0.5" />
+    <PackageReference Include="CryptoExchange.Net" Version="3.0.14" />
   </ItemGroup>
 </Project>

--- a/Okex.Net/OkexAuthenticationProvider.cs
+++ b/Okex.Net/OkexAuthenticationProvider.cs
@@ -35,7 +35,7 @@ namespace Okex.Net
             this.arraySerialization = arraySerialization;
         }
 
-        public override Dictionary<string, string> AddAuthenticationToHeaders(string uri, HttpMethod method, Dictionary<string, object> parameters, bool signed)
+        public override Dictionary<string, string> AddAuthenticationToHeaders(string uri, HttpMethod method, Dictionary<string, object> parameters, bool signed, PostParameters postParameterPosition, ArrayParametersSerialization arraySerialization)
         {
             if (!signed && !signPublicRequests)
                 return new Dictionary<string, string>();

--- a/Okex.Net/OkexClient.cs
+++ b/Okex.Net/OkexClient.cs
@@ -244,17 +244,18 @@ namespace Okex.Net
 		{
 			SetAuthenticationProvider(new OkexAuthenticationProvider(new ApiCredentials(apiKey, apiSecret), passPhrase, SignPublicRequests, ArrayParametersSerialization.Array));
 		}
-		#endregion
+        #endregion
 
-		#region Protected & Private Methods
-		protected override IRequest ConstructRequest(Uri uri, HttpMethod method, Dictionary<string, object>? parameters, bool signed)
+        #region Protected & Private Methods
+
+        protected override IRequest ConstructRequest(Uri uri, HttpMethod method, Dictionary<string, object>? parameters, bool signed, PostParameters postPosition, ArrayParametersSerialization arraySerialization, int requestId)
 		{
 			if (parameters == null)
 				parameters = new Dictionary<string, object>();
 
 			var uriString = uri.ToString();
 			if (authProvider != null)
-				parameters = authProvider.AddAuthenticationToParameters(uriString, method, parameters, signed);
+				parameters = authProvider.AddAuthenticationToParameters(uriString, method, parameters, signed, postPosition, arraySerialization);
 
 			if ((method == HttpMethod.Get || method == HttpMethod.Delete || postParametersPosition == PostParameters.InUri) && parameters?.Any() == true)
 				uriString += "?" + parameters.CreateParamString(true, arraySerialization);
@@ -268,12 +269,12 @@ namespace Okex.Net
 			}
 
 			var contentType = requestBodyFormat == RequestBodyFormat.Json ? Constants.JsonContentHeader : Constants.FormContentHeader;
-			var request = RequestFactory.Create(method, uriString);
+			var request = RequestFactory.Create(method, uriString, requestId);
 			request.Accept = Constants.JsonContentHeader;
 
 			var headers = new Dictionary<string, string>();
 			if (authProvider != null)
-				headers = authProvider.AddAuthenticationToHeaders(uriString, method, parameters!, signed);
+				headers = authProvider.AddAuthenticationToHeaders(uriString, method, parameters!, signed, postPosition, arraySerialization);
 
 			foreach (var header in headers)
 				request.AddHeader(header.Key, header.Value);


### PR DESCRIPTION
- At the time of this commit the latest version of CryptoExchange.NET is 3.0.14, which is incompatible with the previous version OKEx.NET depends on, which is 3.0.5.

- Several method signatures had to change to accomodate additional arguments added by the newer CryptoExchange.NET.