### PR TITLE
fix bug of parsing error for NULL value in API response

### DIFF
--- a/Okex.Net/RestObjects/Trade/OkexOrder.cs
+++ b/Okex.Net/RestObjects/Trade/OkexOrder.cs
@@ -14,7 +14,7 @@ namespace Okex.Net.RestObjects.Trade
         public DateTime UpdateTime { get; set; }
 
         [JsonProperty("fillTime"), JsonConverter(typeof(OkexTimestampConverter))]
-        public DateTime FillTime { get; set; }
+        public DateTime? FillTime { get; set; }
 
         [JsonProperty("ccy")]
         public string Currency { get; set; }
@@ -50,7 +50,7 @@ namespace Okex.Net.RestObjects.Trade
         public OkexOrderState OrderState { get; set; }
 
         [JsonProperty("tgtCcy"), JsonConverter(typeof(QuantityTypeConverter))]
-        public OkexQuantityType QuantityType { get; set; }
+        public OkexQuantityType? QuantityType { get; set; }
 
         [JsonProperty("avgPx")]
         public decimal? AveragePrice { get; set; }


### PR DESCRIPTION
For example, when we place a limit order, but not filled, `FillTime` will be NULL in API response. Then if we use `client.GetOrderDetails(...)` to get order object, it will cause deserialization error.