### PR TITLE
feature:Support Http Reverse Proxy

### DIFF
--- a/Okex.Net/CoreObjects/OkexAuthenticationProvider.cs
+++ b/Okex.Net/CoreObjects/OkexAuthenticationProvider.cs
@@ -44,7 +44,7 @@ namespace Okex.Net.CoreObjects
                 throw new ArgumentException("No valid API credentials provided. Key/Secret/PassPhrase needed.");
 
             var time = (DateTime.UtcNow.ToUnixTimeMilliSeconds() / 1000.0m).ToString(CultureInfo.InvariantCulture);
-            var signtext = time + method.Method.ToUpper() + uri.Replace("https://www.okx.com", "").Trim('?');
+            var signtext = time + method.Method.ToUpper() + new Uri(uri).AbsolutePath.Trim('?');
 
             if (method == HttpMethod.Post)
             {


### PR DESCRIPTION
There is some sign issue when use http-reverse-proxy:
Sign Path should use `Uri.AbsolutePath` instead of `Replace("https://www.okx.com", "")`

I have already fix it in this PR.